### PR TITLE
Add class for current environment to top menu item

### DIFF
--- a/wp-stage-switcher.php
+++ b/wp-stage-switcher.php
@@ -65,7 +65,10 @@ class StageSwitcher {
         'id'     => 'environment',
         'parent' => 'top-secondary',
         'title'  => ucwords($current_stage),
-        'href'   => '#'
+        'href'   => '#',
+        'meta'   => [
+          'class' => 'environment-' . sanitize_html_class(strtolower($current_stage)),
+        ],
       ]);
 
       $admin_bar->add_menu([


### PR DESCRIPTION
This can be used for adding a custom background color for each environments, for example production has _red_ and development _green_.