### PR TITLE
Change logical condition from 'and' to 'or' to fix visibility

### DIFF
--- a/wp-stage-switcher.php
+++ b/wp-stage-switcher.php
@@ -43,7 +43,7 @@ class StageSwitcher {
   }
 
   public function admin_bar_stage_switcher($admin_bar) {
-    if (!defined('ENVIRONMENTS') && !defined('WP_ENV') && !apply_filters('bedrock/stage_switcher_visibility', is_super_admin())) {
+    if (!defined('ENVIRONMENTS') || !defined('WP_ENV') || !apply_filters('bedrock/stage_switcher_visibility', is_super_admin())) {
       return;
     }
 


### PR DESCRIPTION
Hi,

after some test, for me changing logical condition from `and` to `or` fixes the issue reported [here](https://discourse.roots.io/t/stage-switcher-limit-user-visibility/8877). If I'm not wrong, leaving the `and` operator make the switcher disabled only if all the three conditions are true, but we need to hide the switcher if at least one of the three conditions is true.

Hope this helps, thank you!