### PR TITLE
Allow arrays as constants on PHP 7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ $envs = [
 define('ENVIRONMENTS', serialize($envs));
 ```
 
+Note: the `serialize()` call is not needed on PHP 7.0 or newer.
+
 `WP_ENV` must be defined as the current environment:
 
 ```php

--- a/wp-stage-switcher.php
+++ b/wp-stage-switcher.php
@@ -36,7 +36,7 @@ if (file_exists($composer = __DIR__ . '/vendor/autoload.php')) {
  *
  * If you're using PHP 5.6 or older you must serialize $envs first:
  *
- *   define( 'ENVIRONMENTS', serialize( $envs ) );
+ *   define('ENVIRONMENTS', serialize($envs));
  *
  * WP_ENV must be defined as the current environment.
  */
@@ -51,7 +51,7 @@ class StageSwitcher {
       return;
     }
 
-    $stages = maybe_unserialize( ENVIRONMENTS );
+    $stages = maybe_unserialize(ENVIRONMENTS);
     $current_stage = WP_ENV;
 
     foreach($stages as $stage => $url) {

--- a/wp-stage-switcher.php
+++ b/wp-stage-switcher.php
@@ -24,7 +24,7 @@ if (file_exists($composer = __DIR__ . '/vendor/autoload.php')) {
  * Add stage/environment switcher to admin bar
  * Inspired by http://37signals.com/svn/posts/3535-beyond-the-default-rails-environments
  *
- * ENVIRONMENTS constant must be a serialized array of 'environment' => 'url' elements:
+ * ENVIRONMENTS constant must be an array of 'environment' => 'url' elements:
  *
  *   $envs = [
  *    'development' => 'http://example.dev',
@@ -32,9 +32,13 @@ if (file_exists($composer = __DIR__ . '/vendor/autoload.php')) {
  *    'production'  => 'http://example.com'
  *   ];
  *
- *   define('ENVIRONMENTS', serialize($envs));
+ *   define( 'ENVIRONMENTS', $envs );
  *
- * WP_ENV must be defined as the current environment
+ * If you're using PHP 5.6 or older you must serialize $envs first:
+ *
+ *   define( 'ENVIRONMENTS', serialize( $envs ) );
+ *
+ * WP_ENV must be defined as the current environment.
  */
 class StageSwitcher {
   public function __construct() {
@@ -47,7 +51,7 @@ class StageSwitcher {
       return;
     }
 
-    $stages = unserialize(ENVIRONMENTS);
+    $stages = maybe_unserialize( ENVIRONMENTS );
     $current_stage = WP_ENV;
 
     foreach($stages as $stage => $url) {


### PR DESCRIPTION
This makes usage a bit easier when not using an outdated version of PHP.

Thanks to `maybe_unserialize()` this change is backward compatible. Both regular and serialized arrays are supported.