### PR TITLE
Preserve admin URLs using WordPress admin path

### DIFF
--- a/tests/Unit/RelativeUriTest.php
+++ b/tests/Unit/RelativeUriTest.php
@@ -72,3 +72,14 @@ it('assembles correct target URL with query string', function () {
     expect($adminBar->menus['stage_staging']['href'])->toBe('https://staging.example.com/about?foo=bar');
     expect($adminBar->menus['stage_production']['href'])->toBe('https://example.com/about?foo=bar');
 });
+
+it('preserves the WordPress core path in admin target URLs when WordPress is installed in a subdirectory', function () {
+    $_SERVER['REQUEST_URI'] = '/wp/wp-admin/index.php';
+
+    $adminBar = new WP_Admin_Bar;
+    $switcher = new StageSwitcher;
+    $switcher->admin_bar_stage_switcher($adminBar);
+
+    expect($adminBar->menus['stage_staging']['href'])->toBe('https://staging.example.com/wp/wp-admin/index.php');
+    expect($adminBar->menus['stage_production']['href'])->toBe('https://example.com/wp/wp-admin/index.php');
+});

--- a/tests/Unit/RelativeUriTest.php
+++ b/tests/Unit/RelativeUriTest.php
@@ -73,6 +73,10 @@ it('assembles correct target URL with query string', function () {
     expect($adminBar->menus['stage_production']['href'])->toBe('https://example.com/about?foo=bar');
 });
 
+it('preserves admin paths instead of stripping the subdirectory prefix', function () {
+    expect(callRelativeUri(switcher(), '/wp/wp-admin/index.php'))->toBe('/wp/wp-admin/index.php');
+});
+
 it('preserves the WordPress core path in admin target URLs when WordPress is installed in a subdirectory', function () {
     $_SERVER['REQUEST_URI'] = '/wp/wp-admin/index.php';
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,6 +23,13 @@ if (! function_exists('site_url')) {
     }
 }
 
+if (! function_exists('admin_url')) {
+    function admin_url(string $path = ''): string
+    {
+        return rtrim(site_url('/wp-admin/'), '/').'/'.ltrim($path, '/');
+    }
+}
+
 if (! function_exists('apply_filters')) {
     function apply_filters(string $hook, mixed $value, mixed ...$args): mixed
     {

--- a/wp-stage-switcher.php
+++ b/wp-stage-switcher.php
@@ -156,21 +156,32 @@ class StageSwitcher
         $site_path = rtrim((string) wp_parse_url(site_url('/'), PHP_URL_PATH), '/');
         $env_path = rtrim((string) wp_parse_url($this->stages[WP_ENV] ?? '', PHP_URL_PATH), '/');
 
-        $relative_path = null;
+        $prefix = match (true) {
+            $this->path_matches($request_path, $site_path) => $site_path,
+            $this->path_matches($request_path, $env_path) => $env_path,
+            default => null,
+        };
 
-        if ($site_path !== '' && ($request_path === $site_path || str_starts_with($request_path, $site_path.'/'))) {
-            $relative_path = substr($request_path, strlen($site_path));
-        } elseif ($env_path !== '' && ($request_path === $env_path || str_starts_with($request_path, $env_path.'/'))) {
-            $relative_path = substr($request_path, strlen($env_path));
-        }
-
-        if ($relative_path === null) {
+        if ($prefix === null) {
             return $request_uri;
         }
 
-        $relative_path = '/'.ltrim($relative_path, '/');
+        $relative_path = '/'.ltrim(substr($request_path, strlen($prefix)), '/');
+
+        $admin_path = (string) wp_parse_url(admin_url(), PHP_URL_PATH);
+
+        if ($this->path_matches($request_path, $admin_path) || $this->path_matches($relative_path, $admin_path)) {
+            return $request_uri;
+        }
 
         return $relative_path.(is_string($query) && $query !== '' ? "?{$query}" : '');
+    }
+
+    private function path_matches(string $path, string $prefix): bool
+    {
+        $prefix = rtrim($prefix, '/');
+
+        return $prefix !== '' && ($path === $prefix || str_starts_with($path, $prefix.'/'));
     }
 
     private static function default_environment_colors(): array


### PR DESCRIPTION
## Summary

- Preserve admin target URLs when WordPress is installed in a subdirectory
- Add regression coverage for `/wp/wp-admin/index.php` stage switcher links

Closes #32